### PR TITLE
Enable sitemap plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,6 +50,12 @@ const config = {
         gtag: {
           trackingID: 'G-S9KBTW5Q32',
           anonymizeIP: true,
+        },        
+        sitemap: {
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml',
         },
       }),
     ],


### PR DESCRIPTION
default preset theme comes shipping with the sitemap plugin. I enabled it in the config we can submit it to Google console now we updated the urls maybe it helps. 