### PR TITLE
update GA as marketing site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,7 +48,7 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         gtag: {
-          trackingID: 'G-S9KBTW5Q32',
+          trackingID: 'G-464H6Y7FRM',
           anonymizeIP: true,
         },
         sitemap: {


### PR DESCRIPTION
Let's just use a single Google Analytics tracking code across docs and marketing sites. 

This will be easier to report and also deduplicate users across the two sites. 