### PR TITLE
add warning about port number in RTMP

### DIFF
--- a/docs/guides/publish-live-stream/rtmp/publish-with-obs.md
+++ b/docs/guides/publish-live-stream/rtmp/publish-with-obs.md
@@ -28,6 +28,13 @@ We assume that your Ant Media Server accepts all streams (e.g there is no securi
 *   In the URL box, type your RTMP URL without stream id. It's like ```rtmp://IP-or-server-domain-name/LiveApp```
 *   In the Stream key, you can write any stream id because we assume that all stream Ids are allowed.
 
+:::warning
+The RTMP URL should not contain any port number. The RTMP protocol will automatically listen on port 1935 that should be open on your server.
+
+ - **Wrong**: rtmp://am.streamomedia.com:5443/WebRTCAppEE/
+ - **Correct**:   rtmp://am.streamomedia.com/WebRTCAppEE/
+:::
+
 ![](@site/static/img/obs-rtmp-image/OBS-Stream.png)
 
 **Note:** When you use tokens you need to generate a publish token and use it in this format inside the stream key : ```streamdid?token=tokenid```

--- a/docs/guides/publish-live-stream/rtmp/publish-with-obs.md
+++ b/docs/guides/publish-live-stream/rtmp/publish-with-obs.md
@@ -29,7 +29,7 @@ We assume that your Ant Media Server accepts all streams (e.g there is no securi
 *   In the Stream key, you can write any stream id because we assume that all stream Ids are allowed.
 
 :::warning
-The RTMP URL should not contain any port number. The RTMP protocol will automatically listen on port 1935 that should be open on your server.
+The RTMP URL should not contain any port number. The RTMP protocol will automatically listen on port 1935 which should be open on your server.
 
  - **Wrong**: rtmp://am.streamomedia.com:5443/WebRTCAppEE/
  - **Correct**:   rtmp://am.streamomedia.com/WebRTCAppEE/


### PR DESCRIPTION
https://antmedia.io/docs/guides/publish-live-stream/rtmp/publish-with-obs/

Warning not to add port number in RTMP URL and provide example settings when using NVENC encoder. 