### PR TITLE
docs:Recategorize AWS Cluster section

### DIFF
--- a/docs/guides/clustering-and-scaling/aws/aws-cloudformation/_category_.json
+++ b/docs/guides/clustering-and-scaling/aws/aws-cloudformation/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "AWS CloudFormation",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "description": "Deploy Ant Media Server at AWS with AWS CloudFormation."
+  }
+}

--- a/docs/guides/clustering-and-scaling/aws/aws-cloudformation/ant-media-global-cluster-on-aws.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-cloudformation/ant-media-global-cluster-on-aws.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying Ant Media Server Global Cluster On AWS 
-description: Deploying Ant Media Server Global Cluster On AWS
+title: Deploy Ant Media Server Global Cluster On AWS 
+description: Deploy Ant Media Server Global Cluster On AWS
 keywords: [AMS Global Cluster on AWS, Ant Media Server Documentation, Ant Media Server Tutorials]
 sidebar_position: 1
 ---

--- a/docs/guides/clustering-and-scaling/aws/aws-cloudformation/ant-media-global-cluster-on-aws.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-cloudformation/ant-media-global-cluster-on-aws.md
@@ -2,7 +2,7 @@
 title: Deploying Ant Media Server Global Cluster On AWS 
 description: Deploying Ant Media Server Global Cluster On AWS
 keywords: [AMS Global Cluster on AWS, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 11
+sidebar_position: 1
 ---
 
 # Ant Media Server Global Cluster

--- a/docs/guides/clustering-and-scaling/aws/aws-cloudformation/ant-media-global-cluster-on-aws.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-cloudformation/ant-media-global-cluster-on-aws.md
@@ -2,7 +2,7 @@
 title: Deploy Ant Media Server Global Cluster On AWS 
 description: Deploy Ant Media Server Global Cluster On AWS
 keywords: [AMS Global Cluster on AWS, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Ant Media Server Global Cluster

--- a/docs/guides/clustering-and-scaling/aws/aws-cloudformation/scale-with-aws-cloudformation.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-cloudformation/scale-with-aws-cloudformation.md
@@ -2,7 +2,7 @@
 title: Scale AMS with AWS CloudFormation 
 description: Scale AMS with AWS CloudFormation
 keywords: [Scale AMS with AWS CloudFormation, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Scale AMS with AWS CloudFormation

--- a/docs/guides/clustering-and-scaling/aws/aws-cloudformation/scale-with-aws-cloudformation.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-cloudformation/scale-with-aws-cloudformation.md
@@ -2,7 +2,7 @@
 title: Scale AMS with AWS CloudFormation 
 description: Scale AMS with AWS CloudFormation
 keywords: [Scale AMS with AWS CloudFormation, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # Scale AMS with AWS CloudFormation

--- a/docs/guides/clustering-and-scaling/aws/aws-cloudformation/updating-ams-with-cloudformation.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-cloudformation/updating-ams-with-cloudformation.md
@@ -2,7 +2,7 @@
 title: Updating AMS with CloudFormation 
 description: Updating AMS with CloudFormation
 keywords: [Updating AMS with CloudFormation, AWS CloudFormation, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # Updating AMS with CloudFormation

--- a/docs/guides/clustering-and-scaling/aws/aws-cloudformation/updating-ams-with-cloudformation.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-cloudformation/updating-ams-with-cloudformation.md
@@ -2,7 +2,7 @@
 title: Updating AMS with CloudFormation 
 description: Updating AMS with CloudFormation
 keywords: [Updating AMS with CloudFormation, AWS CloudFormation, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 4
+sidebar_position: 3
 ---
 
 # Updating AMS with CloudFormation

--- a/docs/guides/clustering-and-scaling/aws/aws-ecs/_category_.json
+++ b/docs/guides/clustering-and-scaling/aws/aws-ecs/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "AWS ECS",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "Deploy Ant Media Server at AWS with AWS ECS."
+  }
+}

--- a/docs/guides/clustering-and-scaling/aws/aws-ecs/running-ams-container-at-ecs.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-ecs/running-ams-container-at-ecs.md
@@ -2,7 +2,7 @@
 title: Run Ant Media Server (Enterprise Edition) container on ECS in cluster mode 
 description: Run Ant Media Server (Enterprise Edition) container on ECS in cluster mode
 keywords: [ECS in cluster mode, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 9
+sidebar_position: 1
 ---
 
 # Run Ant Media Server Enterprise Edition container on Amazon Elastic Container Service (ECS) in cluster mode

--- a/docs/guides/clustering-and-scaling/aws/aws-ecs/running-ams-container-at-ecs.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-ecs/running-ams-container-at-ecs.md
@@ -1,6 +1,6 @@
 ---
-title: Run Ant Media Server (Enterprise Edition) container on ECS in cluster mode 
-description: Run Ant Media Server (Enterprise Edition) container on ECS in cluster mode
+title: Deploy AMS Cluster on AWS ECS
+description: Deploy AMS Cluster on AWS ECS
 keywords: [ECS in cluster mode, Ant Media Server Documentation, Ant Media Server Tutorials]
 sidebar_position: 1
 ---

--- a/docs/guides/clustering-and-scaling/aws/aws-ecs/scaling-at-aws-ecs-fargate.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-ecs/scaling-at-aws-ecs-fargate.md
@@ -2,7 +2,7 @@
 title: Scale AMS with AWS ECS Fargate 
 description: Scale AMS with AWS ECS Fargate
 keywords: [Scale AMS with AWS ECS Fargate, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 10
+sidebar_position: 2
 ---
 
 # Scale AMS with AWS ECS Fargate

--- a/docs/guides/clustering-and-scaling/aws/aws-lb/_category_.json
+++ b/docs/guides/clustering-and-scaling/aws/aws-lb/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "AWS Load Balancer",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Deploy Ant Media Server at AWS with Load Balancer."
+  }
+}

--- a/docs/guides/clustering-and-scaling/aws/aws-lb/configuring-rtmp-lb-in-aws.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-lb/configuring-rtmp-lb-in-aws.md
@@ -1,11 +1,11 @@
 ---
-title: Configuring RTMP LB in AWS 
-description: Configuring RTMP LB in AWS
+title: Configure RTMP LB in AWS 
+description: Configure RTMP Load Balancer in AWS
 keywords: [Configuring RTMP LB in AWS, Ant Media Server Documentation, Ant Media Server Tutorials]
 sidebar_position: 1
 ---
 
-# Configuring RTMP LB in AWS
+# Configure RTMP LB in AWS
 
 Follow the instructions below to configure RTMP Load Balancer in Ant Media Server Auto Scaling structure.
 

--- a/docs/guides/clustering-and-scaling/aws/aws-lb/configuring-rtmp-lb-in-aws.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-lb/configuring-rtmp-lb-in-aws.md
@@ -2,7 +2,7 @@
 title: Configuring RTMP LB in AWS 
 description: Configuring RTMP LB in AWS
 keywords: [Configuring RTMP LB in AWS, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Configuring RTMP LB in AWS

--- a/docs/guides/clustering-and-scaling/aws/aws-lb/enabling-ip-filtering-behind-load-balancer-in-aws.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-lb/enabling-ip-filtering-behind-load-balancer-in-aws.md
@@ -1,11 +1,11 @@
 ---
-title: Enable IP filter behind AWS load balancer 
-description: Enabling IP filtering behind a load balancer in AWS
+title: Enable IP Filter Behind AWS Load Balancer 
+description: Enable IP filter behind AWS Load Balancer
 keywords: [Load Balancer, Ant Media Server Documentation, Ant Media Server Tutorials]
 sidebar_position: 2
 ---
 
-# Enabling IP filtering behind a load balancer in AWS
+# Enable IP Filter Behind AWS Load Balancer
 
 This document explains how to enable IP filter for Ant Media Server behind a load balancer in AWS. Follow the instructions below.
 

--- a/docs/guides/clustering-and-scaling/aws/aws-lb/enabling-ip-filtering-behind-load-balancer-in-aws.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-lb/enabling-ip-filtering-behind-load-balancer-in-aws.md
@@ -2,7 +2,7 @@
 title: Enable IP filter behind AWS load balancer 
 description: Enabling IP filtering behind a load balancer in AWS
 keywords: [Load Balancer, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 7
+sidebar_position: 2
 ---
 
 # Enabling IP filtering behind a load balancer in AWS

--- a/docs/guides/clustering-and-scaling/aws/aws-wavelenght/_category_.json
+++ b/docs/guides/clustering-and-scaling/aws/aws-wavelenght/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "AWS Wavelenght",
+  "label": "AWS Wavelength",
   "position": 4,
   "link": {
     "type": "generated-index",

--- a/docs/guides/clustering-and-scaling/aws/aws-wavelenght/_category_.json
+++ b/docs/guides/clustering-and-scaling/aws/aws-wavelenght/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "AWS Wavelenght",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Deploy Ant Media Server at AWS."
+  }
+}

--- a/docs/guides/clustering-and-scaling/aws/aws-wavelenght/aws-wavelength-cluster-deployment.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-wavelenght/aws-wavelength-cluster-deployment.md
@@ -2,7 +2,7 @@
 title: AWS Wavelength Cluster Deployment 
 description: AWS Wavelength Cluster Deployment
 keywords: [AWS Wavelength Cluster Deployment, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # AWS Wavelength Cluster Deployment

--- a/docs/guides/clustering-and-scaling/aws/aws-wavelenght/aws-wavelength-cluster-deployment.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-wavelenght/aws-wavelength-cluster-deployment.md
@@ -2,7 +2,7 @@
 title: AWS Wavelength Cluster Deployment 
 description: AWS Wavelength Cluster Deployment
 keywords: [AWS Wavelength Cluster Deployment, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 8
+sidebar_position: 1
 ---
 
 # AWS Wavelength Cluster Deployment

--- a/docs/guides/clustering-and-scaling/aws/aws-wavelenght/aws-wavelength-standalone-deployment.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-wavelenght/aws-wavelength-standalone-deployment.md
@@ -2,7 +2,7 @@
 title: AWS Wavelength Standalone Deployment 
 description: AWS Wavelength Standalone Deployment
 keywords: [AWS Wavelength Standalone Deployment, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # AWS Wavelength Standalone Deployment

--- a/docs/guides/clustering-and-scaling/aws/aws-wavelenght/aws-wavelength-standalone-deployment.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-wavelenght/aws-wavelength-standalone-deployment.md
@@ -2,7 +2,7 @@
 title: AWS Wavelength Standalone Deployment 
 description: AWS Wavelength Standalone Deployment
 keywords: [AWS Wavelength Standalone Deployment, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 6
+sidebar_position: 3
 ---
 
 # AWS Wavelength Standalone Deployment

--- a/docs/guides/clustering-and-scaling/aws/aws-wavelenght/deploying-ams-at-aws-wavelength.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-wavelenght/deploying-ams-at-aws-wavelength.md
@@ -2,7 +2,7 @@
 title: Deploying Ant Media Server at AWS Wavelength 
 description: Deploying Ant Media Server at AWS Wavelength
 keywords: [Deploying Ant Media Server at AWS Wavelength, AWS Wavelength, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 5
+sidebar_position: 2
 ---
 
 # Deploying Ant Media Server at AWS Wavelength

--- a/docs/guides/clustering-and-scaling/aws/aws-wavelenght/deploying-ams-at-aws-wavelength.md
+++ b/docs/guides/clustering-and-scaling/aws/aws-wavelenght/deploying-ams-at-aws-wavelength.md
@@ -1,11 +1,11 @@
 ---
-title: Deploying Ant Media Server at AWS Wavelength 
-description: Deploying Ant Media Server at AWS Wavelength
+title: Deploy Ant Media Server at AWS Wavelength 
+description: Deploy Ant Media Server at AWS Wavelength
 keywords: [Deploying Ant Media Server at AWS Wavelength, AWS Wavelength, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 2
+sidebar_position: 1
 ---
 
-# Deploying Ant Media Server at AWS Wavelength
+# Deploy Ant Media Server at AWS Wavelength
 
 AWS Wavelength enables developers to build applications that deliver ultra-low latencies to mobile devices and end users. Wavelength deploys standard AWS compute and storage services to the edge of telecommunication carriers' 5G networks. 
 

--- a/docs/guides/clustering-and-scaling/aws/clustering-with-aws.md
+++ b/docs/guides/clustering-and-scaling/aws/clustering-with-aws.md
@@ -2,7 +2,7 @@
 title: Clustering with AWS 
 description: Clustering with AWS
 keywords: [Clustering with AWS, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 1
+sidebar_position: 5
 ---
 
 # Clustering with AWS

--- a/docs/guides/clustering-and-scaling/aws/scale-with-self-hosted-license.md
+++ b/docs/guides/clustering-and-scaling/aws/scale-with-self-hosted-license.md
@@ -2,7 +2,7 @@
 title: Scale AMS on AWS using Self-Hosted license
 description: Scale AMS on AWS with AWS CloudFormation using self-hosted license
 keywords: [Scale AMS with AWS CloudFormation, Ant Media Server Documentation, Ant Media Server Tutorials]
-sidebar_position: 12
+sidebar_position: 6
 ---
 
 # Scale AMS with AWS CloudFormation using Self-Hosted license

--- a/docs/guides/clustering-and-scaling/aws/scale-with-self-hosted-license.md
+++ b/docs/guides/clustering-and-scaling/aws/scale-with-self-hosted-license.md
@@ -1,6 +1,6 @@
 ---
 title: Scale AMS on AWS using Self-Hosted license
-description: Scale AMS on AWS with AWS CloudFormation using self-hosted license
+description: Scale AMS on AWS using self-hosted license
 keywords: [Scale AMS with AWS CloudFormation, Ant Media Server Documentation, Ant Media Server Tutorials]
 sidebar_position: 6
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,15 +130,15 @@ scripts: [
         },
         {
           from: '/guides/developer-sdk-and-api/rest-api-guide/enabling-ip-filtering-behind-load-balancer-in-aws/',
-          to: '/guides/clustering-and-scaling/aws/enabling-ip-filtering-behind-load-balancer-in-aws/'
+          to: '/guides/clustering-and-scaling/aws/aws-lb/enabling-ip-filtering-behind-load-balancer-in-aws/'
         },
         {
           from: '/guides/clustering-and-scaling/aws/Configuring-RTMP-LB-in-AWS/',
-          to: '/guides/clustering-and-scaling/aws/configuring-rtmp-lb-in-aws/'
+          to: '/guides/clustering-and-scaling/aws/aws-lb/configuring-rtmp-lb-in-aws/'
         },
         {
           from: '/guides/clustering-and-scaling/aws/Scaling-at-AWS-ECS-Fargate/',
-          to: '/guides/clustering-and-scaling/aws/scaling-at-aws-ecs-fargate/'
+          to: '/guides/clustering-and-scaling/aws/aws-ecs/scaling-at-aws-ecs-fargate/'
         },
         {
           from: '/guides/playing-live-stream/HLS-Playing/',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -234,11 +234,11 @@ scripts: [
         },
 	{
           from: '/v1/docs/how-to-enable-ip-filter-for-ant-media-servers-behind-load-balancer-in-aws/',
-          to: '/guides/clustering-and-scaling/aws/enabling-ip-filtering-behind-load-balancer-in-aws/'
+          to: '/guides/clustering-and-scaling/aws/aws-lb/enabling-ip-filtering-behind-load-balancer-in-aws/'
         },
 	{
           from: '/v1/docs/how-to-configure-rtmp-load-balancer-in-aws/',
-          to: '/guides/clustering-and-scaling/aws/configuring-rtmp-lb-in-aws/'
+          to: '/guides/clustering-and-scaling/aws/aws-lb/configuring-rtmp-lb-in-aws/'
         },
         {
           from: '/guides/developer-sdk-and-api/rest-api-guide/rest-api-guide/',


### PR DESCRIPTION
### What does it do?

This PR re-organizes the categories of documentation for AWS. 
This closes the [issue 385](https://github.com/ant-media/ant-media-documentation/issues/385)

```
├── _category_.json
├── aws-cloudformation
│   ├── _category_.json
│   ├── ant-media-global-cluster-on-aws.md
│   ├── scale-with-aws-cloudformation.md
│   └── updating-ams-with-cloudformation.md
├── aws-ecs
│   ├── _category_.json
│   ├── running-ams-container-at-ecs.md
│   └── scaling-at-aws-ecs-fargate.md
├── aws-lb
│   ├── _category_.json
│   ├── configuring-rtmp-lb-in-aws.md
│   └── enabling-ip-filtering-behind-load-balancer-in-aws.md
├── aws-wavelenght
│   ├── _category_.json
│   ├── aws-wavelength-cluster-deployment.md
│   ├── aws-wavelength-standalone-deployment.md
│   └── deploying-ams-at-aws-wavelength.md
├── clustering-with-aws.md
└── scale-with-self-hosted-license.md
```

### Why is it needed?

The documentation for AWS is too complicated and instructed. 

### Related issue(s)/PR(s)
https://github.com/ant-media/ant-media-documentation/issues/385
